### PR TITLE
Fix FPM deb packaging output and add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/python/pack_fpm-deb
+++ b/python/pack_fpm-deb
@@ -32,7 +32,7 @@ def main() -> None:
         "--python-package-name-prefix",
         "python3",
         "--log",
-        "info",
+        "error",
         "-f",
     ]
 

--- a/python/tests/fpmDebTest.py
+++ b/python/tests/fpmDebTest.py
@@ -60,6 +60,10 @@ class FpmDebTest(TestCase):
         )
         self.assertTrue(check_files_exist(result.stdout))
 
+    def test_fpm_deb_when_output_already_exists(self):
+        self.test_fpm_deb_when_relative_output_dir_specified()
+        self.test_fpm_deb_when_relative_output_dir_specified()
+
     def test_fpm_deb_when_absolute_output_dir_specified(self):
         # Given
         command = [


### PR DESCRIPTION
Correct the FPM deb packaging output behavior when the deb file already exists and introduce Dependabot for automated dependency updates.